### PR TITLE
fix(ControlBar): optimize model saving process in ControlBar component

### DIFF
--- a/src/components/ControlBar.tsx
+++ b/src/components/ControlBar.tsx
@@ -51,30 +51,37 @@ export default function ControlBar(props: ControlBarProps): React.ReactElement {
   const { modelSaveSubs, worker, setRestorePopupVisible } = props;
 
   useEffect(() => {
-    modelSaveSubs.push((sav: ModelSave) => {
-      save(sav);
-    });
-    // take the json and have the user download it
-    function save(sav: ModelSave): void {
-      const filename = `${sav.modelType}@${sav.time}`;
-      const dat = JSON.stringify(sav);
-      const blob = new Blob([dat], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = filename;
-      link.style.display = 'none';
-      document.body.appendChild(link);
-
-      link.click();
-
-      URL.revokeObjectURL(url);
-      document.body.removeChild(link);
-
-      console.log('wrote a save to ' + filename, sav);
+    if (!modelSaveSubs.includes(save)) {
+      modelSaveSubs.push(save);
     }
+    return () => {
+      const index = modelSaveSubs.findIndex((value) => value === save);
+      if (index !== -1) {
+        modelSaveSubs.splice(index, 1);
+      }
+    };
   }, [modelSaveSubs]);
+
+  // take the json and have the user download it
+  function save(sav: ModelSave): void {
+    const filename = `${sav.modelType}@${sav.time}.json`;
+    const dat = JSON.stringify(sav);
+    const blob = new Blob([dat], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+
+    link.click();
+
+    URL.revokeObjectURL(url);
+    document.body.removeChild(link);
+
+    console.log('wrote a save to ' + filename, sav);
+  }
 
   // take a file and send its contents to the worker
 


### PR DESCRIPTION
lost in Changelog CI so recreate that PR.
Commit ensures that the 'save' function is subscribed only once to modelSaveSubs - an established change of model state. It guarantees that the act of subscribing and unsubscribing is done smoothly everytime modelsave state changes, ensuring optimised performance and logical clean up. The filename for saved files also now includes '.json' extension for appropriate categorization.