### PR TITLE
ci(changelog): pull repo before push

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,6 +24,8 @@ jobs:
         run: go install github.com/git-chglog/git-chglog/cmd/git-chglog@latest
       - name: Generate changelog
         run: git-chglog --next-tag 'Unreleased' --output CHANGELOG.md
+      - name: Pull changes
+        run: git pull origin main --rebase
       - name: Commit changelog
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
@@ -31,4 +33,3 @@ jobs:
           commit_options: '--no-verify --signoff'
           file_pattern: CHANGELOG.md
           push_options: --force
-          


### PR DESCRIPTION
To prevent the force push overwrite the most recent merge
when merging multiple PRs at the same time

Signed-off-by: Bill ZHANG <36790218+Lutra-Fs@users.noreply.github.com>